### PR TITLE
[Feature/#28] todos CRUD 상태 로직 변경

### DIFF
--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -74,7 +74,8 @@
 		"import/prefer-default-export": "off",
 		"react/jsx-no-constructed-context-values": "off",
 		"no-param-reassign": "off",
-		"no-use-before-define": "off"
+		"no-use-before-define": "off",
+		"no-console": "off"
 	},
 	"settings": {
 		"import/parsers": {

--- a/client/src/components/InputForm/index.tsx
+++ b/client/src/components/InputForm/index.tsx
@@ -7,20 +7,26 @@ import { ChangeEvent, FormEvent, useCallback, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { addTodo } from '@store/todos';
 import { AppDispatch } from '@store/index';
+import Spinner from '@components/Spinner';
 
 const InputForm = () => {
 	const [keyword, setKeyword] = useState('');
+	const [loading, setLoading] = useState(false);
 
 	const dispatch = useDispatch<AppDispatch>();
 
 	const handleSubmit = useCallback(
-		(e: FormEvent<HTMLFormElement>) => {
+		async (e: FormEvent<HTMLFormElement>) => {
 			try {
+				setLoading(() => true);
+
 				e.preventDefault();
-				dispatch(addTodo({ title: keyword }));
+				await dispatch(addTodo({ title: keyword }));
 				setKeyword(() => '');
 			} catch (e) {
 				console.error(e);
+			} finally {
+				setLoading(() => false);
 			}
 		},
 		[dispatch, keyword],
@@ -38,9 +44,13 @@ const InputForm = () => {
 
 			<Input type="text" value={keyword} onChange={handleChange} autoFocus />
 
-			<Button type="submit" css={PlusButtonStyle}>
-				<FaPlusCircle />
-			</Button>
+			{loading ? (
+				<Spinner />
+			) : (
+				<Button type="submit" css={PlusButtonStyle}>
+					<FaPlusCircle />
+				</Button>
+			)}
 		</Container>
 	);
 };

--- a/client/src/components/InputForm/index.tsx
+++ b/client/src/components/InputForm/index.tsx
@@ -10,13 +10,18 @@ import { AppDispatch } from '@store/index';
 
 const InputForm = () => {
 	const [keyword, setKeyword] = useState('');
+
 	const dispatch = useDispatch<AppDispatch>();
 
 	const handleSubmit = useCallback(
 		(e: FormEvent<HTMLFormElement>) => {
-			e.preventDefault();
-			dispatch(addTodo({ title: keyword }));
-			setKeyword(() => '');
+			try {
+				e.preventDefault();
+				dispatch(addTodo({ title: keyword }));
+				setKeyword(() => '');
+			} catch (e) {
+				console.error(e);
+			}
 		},
 		[dispatch, keyword],
 	);

--- a/client/src/components/InputForm/index.tsx
+++ b/client/src/components/InputForm/index.tsx
@@ -5,7 +5,7 @@ import color from '@assets/color';
 import { css } from '@emotion/react';
 import { ChangeEvent, FormEvent, useCallback, useState } from 'react';
 import { useDispatch } from 'react-redux';
-import { addTodo, getTodoList } from '@store/todos';
+import { addTodo } from '@store/todos';
 import { AppDispatch } from '@store/index';
 
 const InputForm = () => {
@@ -16,7 +16,6 @@ const InputForm = () => {
 		(e: FormEvent<HTMLFormElement>) => {
 			e.preventDefault();
 			dispatch(addTodo({ title: keyword }));
-			dispatch(getTodoList());
 			setKeyword(() => '');
 		},
 		[dispatch, keyword],

--- a/client/src/components/TodoItem/index.tsx
+++ b/client/src/components/TodoItem/index.tsx
@@ -7,7 +7,7 @@ import { FaTrash } from 'react-icons/fa';
 import { css } from '@emotion/react';
 import { ChangeEvent, useCallback } from 'react';
 import { useDispatch } from 'react-redux';
-import { getTodoList, removeTodo, updateTodo } from '@store/todos';
+import { removeTodo, updateTodo } from '@store/todos';
 import { AppDispatch } from '@store/index';
 
 const TodoItem = ({ id, title, complete }: Todo) => {
@@ -17,14 +17,12 @@ const TodoItem = ({ id, title, complete }: Todo) => {
 		(e: ChangeEvent<HTMLInputElement>) => {
 			const complete = e.target.checked;
 			dispatch(updateTodo({ id, title, complete }));
-			dispatch(getTodoList());
 		},
 		[dispatch, title, id],
 	);
 
 	const handleClick = useCallback(() => {
 		dispatch(removeTodo({ id }));
-		dispatch(getTodoList());
 	}, [dispatch, id]);
 
 	return (

--- a/client/src/components/TodoItem/index.tsx
+++ b/client/src/components/TodoItem/index.tsx
@@ -5,12 +5,14 @@ import font from '@assets/font';
 import color from '@assets/color';
 import { FaTrash } from 'react-icons/fa';
 import { css } from '@emotion/react';
-import { ChangeEvent, useCallback } from 'react';
+import { ChangeEvent, useCallback, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { removeTodo, updateTodo } from '@store/todos';
 import { AppDispatch } from '@store/index';
+import Spinner from '@components/Spinner';
 
 const TodoItem = ({ id, title, complete }: Todo) => {
+	const [loading, setLoading] = useState(false);
 	const dispatch = useDispatch<AppDispatch>();
 
 	const handleChange = useCallback(
@@ -25,11 +27,15 @@ const TodoItem = ({ id, title, complete }: Todo) => {
 		[dispatch, title, id],
 	);
 
-	const handleClick = useCallback(() => {
+	const handleClick = useCallback(async () => {
 		try {
-			dispatch(removeTodo({ id }));
+			setLoading(() => true);
+
+			await dispatch(removeTodo({ id }));
 		} catch (e) {
 			console.error(e);
+		} finally {
+			setLoading(() => false);
 		}
 	}, [dispatch, id]);
 
@@ -40,7 +46,7 @@ const TodoItem = ({ id, title, complete }: Todo) => {
 			<Content>{complete ? <del>{title}</del> : title}</Content>
 
 			<Button type="button" onClick={handleClick}>
-				<FaTrash css={RemoveButtonStyle} />
+				{loading ? <Spinner /> : <FaTrash css={RemoveButtonStyle} />}
 			</Button>
 		</Container>
 	);

--- a/client/src/components/TodoItem/index.tsx
+++ b/client/src/components/TodoItem/index.tsx
@@ -15,14 +15,22 @@ const TodoItem = ({ id, title, complete }: Todo) => {
 
 	const handleChange = useCallback(
 		(e: ChangeEvent<HTMLInputElement>) => {
-			const complete = e.target.checked;
-			dispatch(updateTodo({ id, title, complete }));
+			try {
+				const complete = e.target.checked;
+				dispatch(updateTodo({ id, title, complete }));
+			} catch (e) {
+				console.error(e);
+			}
 		},
 		[dispatch, title, id],
 	);
 
 	const handleClick = useCallback(() => {
-		dispatch(removeTodo({ id }));
+		try {
+			dispatch(removeTodo({ id }));
+		} catch (e) {
+			console.error(e);
+		}
 	}, [dispatch, id]);
 
 	return (

--- a/client/src/store/todos/index.ts
+++ b/client/src/store/todos/index.ts
@@ -17,7 +17,8 @@ export const getTodoList = createAsyncThunk(
 export const addTodo = createAsyncThunk(
 	`${RESOURCE}/addTodo`,
 	async ({ title }: { title: string }) => {
-		await api.createTodo({ title });
+		const data = await api.createTodo({ title });
+		return data;
 	},
 );
 
@@ -32,7 +33,8 @@ export const updateTodo = createAsyncThunk(
 		title: string;
 		complete: boolean;
 	}) => {
-		await api.patchTodo(id, { title, complete });
+		const data = await api.patchTodo(id, { title, complete });
+		return data;
 	},
 );
 
@@ -40,6 +42,7 @@ export const removeTodo = createAsyncThunk(
 	`${RESOURCE}/removeTodo`,
 	async ({ id }: { id: string }) => {
 		await api.deleteTodo(id);
+		return id;
 	},
 );
 
@@ -68,19 +71,25 @@ export const todos = createSlice({
 		[addTodo.pending.type]: (state) => {
 			state.loading = true;
 		},
-		[addTodo.fulfilled.type]: (state) => {
+		[addTodo.fulfilled.type]: (state, action) => {
 			state.loading = false;
+			state.data.push(action.payload);
 		},
 		[updateTodo.pending.type]: (state) => {
 			state.loading = true;
 		},
-		[updateTodo.fulfilled.type]: (state) => {
+		[updateTodo.fulfilled.type]: (state, action) => {
+			state.data = state.data.map((todo) =>
+				todo.id === action.payload.id ? action.payload : todo,
+			);
+
 			state.loading = false;
 		},
 		[removeTodo.pending.type]: (state) => {
 			state.loading = true;
 		},
-		[removeTodo.fulfilled.type]: (state) => {
+		[removeTodo.fulfilled.type]: (state, action) => {
+			state.data = state.data.filter(({ id }) => id !== action.payload);
 			state.loading = false;
 		},
 	},


### PR DESCRIPTION
## 📌 ISSUE

<!-- PR이 연결된 이슈 번호 작성 -->
<!-- ex) closed #[이슈번호] -->
> closed #28 
## 📝 Description

<!-- PR 내용 요약 -->
기존 CRUD 기능 동작 후 서버 데이터 상태의 동기화를 위해 동작하는 로직을 로컬 상태를 기반으로 동작하도록 변경
## 🛠 Features

<!-- 리스트 기록 -->
<!-- - task1 -->
<!-- - task2 -->
<!-- - task3 -->
- todos CRUD 상태 로직 수정
- 비동기 요청 예외처리 구현
- loading animation 구현
